### PR TITLE
Add delayed_job_dashboard.css to the list of assets to precompile.

### DIFF
--- a/lib/delayed_job_dashboard/engine.rb
+++ b/lib/delayed_job_dashboard/engine.rb
@@ -2,10 +2,12 @@ module DelayedJobDashboard
   require 'delayed_job_dashboard'
   require 'rails'
   require 'haml'
- class Engine < Rails::Engine
+  class Engine < Rails::Engine
     engine_name :delayed_job_dashboard
-    paths["app"]         # => ["app/helpers"]
-    #paths["app/helpers"]         # => ["app/helpers"]
-                             #  end
-   end
+    paths["app"]
+
+    initializer :assets do |config|
+      Rails.application.config.assets.precompile += %w( delayed_job_dashboard.css )
+    end
+  end
 end


### PR DESCRIPTION
I based the code on http://thomas.vondeyen.com/2011/11/09/precompile-assets-from-rails-3-1-engines/ (which seems to be the canonical reference for this issue).  It works in my own app.
