### PR TITLE
Fix query for failing jobs

### DIFF
--- a/app/controllers/delayed_jobs_controller.rb
+++ b/app/controllers/delayed_jobs_controller.rb
@@ -45,7 +45,6 @@ class DelayedJobsController < ActionController::Base
   def failing_jobs
     Delayed::Job.
       where("attempts >= 1").
-      where("locked_by is null").
       where("failed_at is not null")
   end
   def overdue_jobs


### PR DESCRIPTION
The `locked_by` attribute is apparently not unset when the job fails.  Regardless, it's really only the `failed_at` attribute that matters for "failing" jobs.
